### PR TITLE
feat: add function associations to CloudFront cache behaviors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.0]() (2026-04-22)
+
+### Features
+
+* Add `function_association` support to `default_cache_behavior` and `ordered_cache_behaviors` in the CloudFront module.
+
 ## [1.0.0]() (2025-07-02)
 
 ### ⚠ BREAKING CHANGES

--- a/modules/cloudfront/main.tf
+++ b/modules/cloudfront/main.tf
@@ -86,6 +86,15 @@ resource "aws_cloudfront_distribution" "this" {
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = local.s3_origin_id
 
+    dynamic "function_association" {
+      for_each = var.default_cache_behavior.function_association != null ? [1] : []
+
+      content {
+        event_type   = var.default_cache_behavior.function_association.event_type
+        function_arn = var.default_cache_behavior.function_association.function_arn
+      }
+    }
+
     forwarded_values {
       query_string = false
 
@@ -103,12 +112,22 @@ resource "aws_cloudfront_distribution" "this" {
 
   dynamic "ordered_cache_behavior" {
     for_each = var.ordered_cache_behaviors
+
     content {
       path_pattern               = ordered_cache_behavior.value.path_pattern
       allowed_methods            = ordered_cache_behavior.value.allowed_methods
       cached_methods             = ordered_cache_behavior.value.cached_methods
       target_origin_id           = ordered_cache_behavior.value.target_origin_id
       response_headers_policy_id = var.enabled_response_headers_policy ? aws_cloudfront_response_headers_policy.this[0].id : null
+
+      dynamic "function_association" {
+        for_each = ordered_cache_behavior.value.function_association != null ? [1] : []
+
+        content {
+          event_type   = ordered_cache_behavior.value.function_association.event_type
+          function_arn = ordered_cache_behavior.value.function_association.function_arn
+        }
+      }
 
       forwarded_values {
         query_string = ordered_cache_behavior.value.query_string

--- a/modules/cloudfront/variables.tf
+++ b/modules/cloudfront/variables.tf
@@ -157,5 +157,5 @@ variable "default_cache_behavior" {
       function_arn = string
     }), null)
   })
-  default = null
+  default = {}
 }

--- a/modules/cloudfront/variables.tf
+++ b/modules/cloudfront/variables.tf
@@ -73,6 +73,10 @@ variable "ordered_cache_behaviors" {
     default_ttl      = number
     max_ttl          = number
     compress         = bool
+    function_association = optional(object({
+      event_type = string
+      function_arn = string
+    }), null)
   }))
   default = []
 }
@@ -143,4 +147,15 @@ variable "s3_redirect_domain" {
   description = "If set, configures the S3 bucket as a static website redirect to this domain."
   type        = string
   default     = null
+}
+
+variable "default_cache_behavior" {
+  description = ""
+  type = object({
+    function_association = optional(object({
+      event_type   = string
+      function_arn = string
+    }), null)
+  })
+  default = null
 }


### PR DESCRIPTION
## Summary

### Why
CloudFront distributions sometimes need to associate Lambda@Edge or CloudFront Functions with cache behaviors to handle request/response manipulation (e.g., URL rewrites, header injection, auth checks). Previously, the module did not support function associations, limiting its flexibility for these use cases.

### What
- Added optional `function_association` block to the `default_cache_behavior` variable in the CloudFront module.
- Added optional `function_association` attribute to each item in the `ordered_cache_behaviors` variable.
- Added dynamic `function_association` blocks in `main.tf` for both default and ordered cache behaviors, only rendered when a function association is provided.

### Solution
Used Terraform `dynamic` blocks with a conditional `for_each` (checking for `null`) to keep the association optional. This avoids breaking existing configurations that don't use function associations, while enabling new deployments to attach CloudFront Functions or Lambda@Edge to any cache behavior.

## Types of Changes
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
1. Deploy a CloudFront distribution using this module with a `function_association` set on `default_cache_behavior` pointing to a valid CloudFront Function ARN.
2. Verify the association appears in the AWS Console under the distribution's cache behavior.
3. Deploy without `function_association` (default `null`) and confirm no regressions — distribution creates/updates successfully.
4. Repeat for `ordered_cache_behaviors` with and without `function_association`.

## Related Issues
N/A